### PR TITLE
Allow to add custom payload entries based on event

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Ah::Lograge.filter_params do |params|
 end
 ```
 
+### Custom payload entries adding
+
+in `config/initializers/lograge.rb` add something like:
+
+```ruby
+Ah::Lograge.additional_custom_entries do |event|
+  { something: event.payload[:something] }
+end
+```
+
 ## Sidekiq Statsd Middleware
 The middleware requires sidekiq and statsd-ruby to operate (it needs to be provided in application gemfile).
 It will report various sidekiq metrics via statsd. There is a penalty: job execution duration will be 0.08s longer (we can live with that).

--- a/lib/ah/lograge.rb
+++ b/lib/ah/lograge.rb
@@ -5,6 +5,7 @@ require 'ah/lograge/railtie'
 module Ah
   module Lograge
     @@filter_params_block = nil
+    @@additional_custom_entries_block = nil
 
     def self.filter_params(&block)
       @@filter_params_block = block
@@ -12,6 +13,14 @@ module Ah
 
     def self.filter_params_block
       @@filter_params_block
+    end
+
+    def self.additional_custom_entries(&block)
+      @@additional_custom_entries_block = block
+    end
+
+    def self.additional_custom_entries_block
+      @@additional_custom_entries_block
     end
   end
 end

--- a/lib/ah/lograge/custom_options_preparer.rb
+++ b/lib/ah/lograge/custom_options_preparer.rb
@@ -4,11 +4,15 @@ module Ah
       NOT_LOGGED_PARAMS = %w(controller action format utf8).freeze
 
       def self.prepare_custom_options(event)
-        {
+        params = {
           params: prepare_params(event.payload[:params]),
           exception: event.payload[:exception],
           exception_object: event.payload[:exception_object]
         }
+
+        params.merge!(Ah::Lograge.additional_custom_entries_block.(event)) if Ah::Lograge.additional_custom_entries_block
+
+        params
       end
 
       def self.prepare_params(event_params)


### PR DESCRIPTION
Allow adding new payload entries based on Events instrumentation. Example:

```
Ah::Lograge.additional_custom_entries do |event|
  options = {}
  options[:es] = event.payload[:elasticsearch_runtime].to_f.round(2) if event.payload[:elasticsearch_runtime]
  options
end
```