### PR TITLE
[AIR-17324] notify statsd about exception

### DIFF
--- a/lib/ah/lograge/airbrake.rb
+++ b/lib/ah/lograge/airbrake.rb
@@ -1,2 +1,3 @@
 require 'ah/lograge/airbrake_patches/active_record' if defined? ActiveRecord
 require 'ah/lograge/airbrake_patches/httparty' if defined? HTTParty
+require 'ah/lograge/airbrake_patches/statsd'

--- a/lib/ah/lograge/airbrake_patches/statsd.rb
+++ b/lib/ah/lograge/airbrake_patches/statsd.rb
@@ -1,0 +1,20 @@
+module Ah
+  module Lograge
+    class Railtie < ::Rails::Railtie
+      config.after_initialize do |app|
+        if defined?(Statsd) && defined?(Airbrake)
+          Airbrake.add_filter do |notice|
+            @client ||=  if defined?($statsd) && $statsd.is_a?(Statsd)
+              $statsd
+            else
+              Statsd.new(ENV['STATSD_HOST'])
+            end
+
+            @client.increment('exceptions')
+          end
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
https://jira.airhelp.com/browse/AIR-17324

I've used rails engine callback to attach proper filter, this way the order of loading gems in `Gemfile` does not matter. Filter gets properly registered, but don't know how to test it locally.

I've got inspiration from: https://github.com/jimeh/airbrake-statsd

```
Airbrake.instance_variable_get('@notifiers')[:default].instance_variable_get('@filter_chain')
=> #<Airbrake::FilterChain:0x00007fbdd9203160
 @filters=
  [#<Proc:0x00007fbdd8da0028@/Users/Przemyslaw.Wroblewski/.rvm/gems/ruby-2.5.1/gems/airbrake-ruby-1.6.0/lib/airbrake-ruby/filter_chain.rb:28>,
   #<Proc:0x00007fbdd8da0050@/Users/Przemyslaw.Wroblewski/.rvm/gems/ruby-2.5.1/gems/airbrake-ruby-1.6.0/lib/airbrake-ruby/filter_chain.rb:10>,
   #<Proc:0x00007fbdd9202d28@/Users/Przemyslaw.Wroblewski/workspace/ah-ota-integration/config/initializers/errbit.rb:16>,
   #<Proc:0x00007fbddf3adaf0@/Users/Przemyslaw.Wroblewski/workspace/ah-lograge/lib/ah/lograge/airbrake_patches/statsd.rb:6>]>
```