### PR TITLE
[AIR-21660] instrumentation for httparty gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ Sidekiq.configure_server do |config|
 end
 ```
 
+## HTTParty tracing
+by default all calls will be gathered and reported by hostname like:
+```
+Completed 200 OK in 3222ms (Views: 81.2ms | ActiveRecord: 204.4ms | Http(airspace.ahinternal.net): 1944.4ms | Http(herman-staging.ahinternal.net): 313.2ms)
+```
+if there is defined global variable `$statsd` with Statsd client instance 
+it will be used to trace execution times and invocation counts
+
+### Usage
+```ruby
+gem 'ah-lograge', require: ['ah/lograge/httparty']
+
+class Gateway
+  include HTTParty
+  include Ah::Lograge::HTTParty::Instrumentation
+end
+```
 
 ## Contributing
 Just create a PR & ping #dev-room or our developers email.

--- a/lib/ah/lograge/httparty.rb
+++ b/lib/ah/lograge/httparty.rb
@@ -1,0 +1,6 @@
+require 'ah/lograge/httparty/instrumentation'
+if defined? ::Rails
+  require 'ah/lograge/httparty/controller_runtime'
+  require 'ah/lograge/httparty/log_subscriber'
+  require 'ah/lograge/httparty/railtie'
+end

--- a/lib/ah/lograge/httparty/controller_runtime.rb
+++ b/lib/ah/lograge/httparty/controller_runtime.rb
@@ -1,6 +1,11 @@
 module Ah
   module Lograge
     module HTTParty
+      #
+      # that concern is only used on local development with lograge disabled
+      # it will log total time spent in http calls to other services along views & db times:
+      # (Views: 71.7ms | ActiveRecord: 70.7ms | HttpAirspace: 9820.2ms | HttpHermanStaging: 380.2ms)
+      #
       module ControllerRuntime
         extend ActiveSupport::Concern
 
@@ -19,10 +24,7 @@ module Ah
             messages, http_runtime = super, payload[:ah_http_runtime]
             http_runtime.each do |service, time|
               if time > 0
-                messages << ("Http(#{ service }): %.1fms" % time)
-                if defined?(Statsd) && defined?($statsd)
-                  $statsd.timing("http/#{ service }", time)
-                end
+                messages << ("#{ service.titleize.tr(' ', '') }: %.1fms" % time)
               end
             end
             messages

--- a/lib/ah/lograge/httparty/controller_runtime.rb
+++ b/lib/ah/lograge/httparty/controller_runtime.rb
@@ -1,0 +1,35 @@
+module Ah
+  module Lograge
+    module HTTParty
+      module ControllerRuntime
+        extend ActiveSupport::Concern
+
+        protected
+
+        attr_internal :ah_http_runtime
+
+        def append_info_to_payload(payload)
+          super
+          http_runtime = Ah::Lograge::HTTParty::LogSubscriber.reset_runtime
+          payload[:ah_http_runtime] = http_runtime
+        end
+
+        module ClassMethods
+          def log_process_action(payload)
+            messages, http_runtime = super, payload[:ah_http_runtime]
+            http_runtime.each do |service, time|
+              if time > 0
+                messages << ("Http(#{ service }): %.1fms" % time)
+                if defined?(Statsd) && defined?($statsd)
+                  $statsd.timing("http/#{ service }", time)
+                end
+              end
+            end
+            messages
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/ah/lograge/httparty/instrumentation.rb
+++ b/lib/ah/lograge/httparty/instrumentation.rb
@@ -1,0 +1,21 @@
+module Ah
+  module Lograge
+    module HTTParty
+      module Instrumentation
+        extend ActiveSupport::Concern
+
+        class_methods do
+          def perform_request(http_method, path, options, &block) #:nodoc:
+            uri = URI.parse(base_uri)
+            if defined?(Statsd) && defined?($statsd)
+              $statsd.increment("http/#{ uri.host }")
+            end
+            ActiveSupport::Notifications.instrument("request.http", hostname: uri.host) do
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ah/lograge/httparty/instrumentation.rb
+++ b/lib/ah/lograge/httparty/instrumentation.rb
@@ -7,9 +7,6 @@ module Ah
         class_methods do
           def perform_request(http_method, path, options, &block) #:nodoc:
             uri = URI.parse(base_uri)
-            if defined?(Statsd) && defined?($statsd)
-              $statsd.increment("http/#{ uri.host }")
-            end
             ActiveSupport::Notifications.instrument("request.http", hostname: uri.host) do
               super
             end

--- a/lib/ah/lograge/httparty/log_subscriber.rb
+++ b/lib/ah/lograge/httparty/log_subscriber.rb
@@ -1,0 +1,22 @@
+module Ah
+  module Lograge
+    module HTTParty
+      class LogSubscriber < ActiveSupport::LogSubscriber
+        def self.add_runtime(hostname, duration)
+          Thread.current[:ah_http_runtime] ||= Hash.new(0)
+          Thread.current[:ah_http_runtime][hostname] += duration
+        end
+
+        def self.reset_runtime
+          rt = Thread.current[:ah_http_runtime]
+          Thread.current[:ah_http_runtime] = Hash.new(0)
+          rt
+        end
+
+        def request(event)
+          self.class.add_runtime(event.payload[:hostname], event.duration)
+        end
+      end
+    end
+  end
+end

--- a/lib/ah/lograge/httparty/log_subscriber.rb
+++ b/lib/ah/lograge/httparty/log_subscriber.rb
@@ -2,19 +2,42 @@ module Ah
   module Lograge
     module HTTParty
       class LogSubscriber < ActiveSupport::LogSubscriber
+        STRIP_SUFFIX = %r[.ahinternal.net]
+        PREFIX = 'http_'
+        THREAD_KEY = :ah_lograge_http_runtime
+
         def self.add_runtime(hostname, duration)
-          Thread.current[:ah_http_runtime] ||= Hash.new(0)
-          Thread.current[:ah_http_runtime][hostname] += duration
+          Thread.current[THREAD_KEY] ||= Hash.new(0)
+          Thread.current[THREAD_KEY][hostname] += duration
         end
 
         def self.reset_runtime
-          rt = Thread.current[:ah_http_runtime]
-          Thread.current[:ah_http_runtime] = Hash.new(0)
-          rt
+          http_runtime = Thread.current[THREAD_KEY]
+          Thread.current[THREAD_KEY] = Hash.new(0)
+          return {} unless http_runtime
+          http_runtime.keys.each do |hostname|
+            http_runtime[service_key(hostname)] = http_runtime[hostname].round(2)
+            http_runtime.delete(hostname)
+          end
+          http_runtime
         end
 
         def request(event)
+          unless Rails.application.config.lograge.enabled
+            text = "  HTTP (#{ event.duration.round(2) }ms) to #{ event.payload[:hostname] } completed"
+            Rails.logger.debug(color(text, :GREEN, bold=false))
+          end
+          if defined?(Statsd) && defined?($statsd)
+            $statsd.increment("http/count/#{ event.payload[:hostname] }")
+            $statsd.timing("http/time/#{ event.payload[:hostname] }", event.duration.round(2))
+          end
           self.class.add_runtime(event.payload[:hostname], event.duration)
+        end
+
+        private
+
+        def self.service_key(hostname)
+          PREFIX + hostname.gsub(STRIP_SUFFIX, '')
         end
       end
     end

--- a/lib/ah/lograge/httparty/railtie.rb
+++ b/lib/ah/lograge/httparty/railtie.rb
@@ -2,10 +2,27 @@ module Ah
   module Lograge
     module HTTParty
       class Railtie < ::Rails::Railtie
+        STRIP_SUFFIX = %r[.ahinternal.net]
+        PREFIX = 'http_'
+
         config.after_initialize do |app|
           Ah::Lograge::HTTParty::LogSubscriber.attach_to :http
-          ActiveSupport.on_load(:action_controller) do
-            include Ah::Lograge::HTTParty::ControllerRuntime
+          if !app.config.lograge.enabled && Rails.env.development?
+            ActiveSupport.on_load(:action_controller) do
+              include Ah::Lograge::HTTParty::ControllerRuntime
+            end
+          end
+          previous_additional_custom_entries_block = nil
+          if Ah::Lograge.additional_custom_entries_block.respond_to?(:call)
+            previous_additional_custom_entries_block = Ah::Lograge.additional_custom_entries_block
+          end
+          Ah::Lograge.additional_custom_entries do |event|
+            http_runtime = Ah::Lograge::HTTParty::LogSubscriber.reset_runtime
+            # there might be a custom block defined already
+            if previous_additional_custom_entries_block
+              http_runtime.merge!(previous_additional_custom_entries_block.call(event))
+            end
+            http_runtime
           end
         end
       end

--- a/lib/ah/lograge/httparty/railtie.rb
+++ b/lib/ah/lograge/httparty/railtie.rb
@@ -1,0 +1,14 @@
+module Ah
+  module Lograge
+    module HTTParty
+      class Railtie < ::Rails::Railtie
+        config.after_initialize do |app|
+          Ah::Lograge::HTTParty::LogSubscriber.attach_to :http
+          ActiveSupport.on_load(:action_controller) do
+            include Ah::Lograge::HTTParty::ControllerRuntime
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
logs external services times using rails stack.
1. local development
<img width="865" alt="screen shot 2018-08-17 at 15 07 44" src="https://user-images.githubusercontent.com/249655/44268304-56e8e180-a231-11e8-9ff5-58e1fd4a3fba.png">

2. stag/prod with lograge (sending to kibana):
when used with enabled lograge event is logged as:

```
{"method":"GET","path":"/api/clients/webapp/critical_events","format":"json",
"controller":"Api::CriticalEventsController","action":"index","status":200,
"duration":10327.94,"view":67.21,"db":34.23,"params":{...}, 
"exception":null,"exception_object":null,
"http_airspace":9164.64,
"http_herman-staging":382.19,
"message":"[200] GET /api/clients/webapp/critical_events (Api::CriticalEventsController#index)"}
```

3. statsd
if `$statsd` is defined trace execution times/counters