### PR TITLE
Improve HTTParty instrumentation (it was failing on nil base_uri)

### DIFF
--- a/lib/ah/lograge/httparty/instrumentation.rb
+++ b/lib/ah/lograge/httparty/instrumentation.rb
@@ -6,7 +6,7 @@ module Ah
 
         class_methods do
           def perform_request(http_method, path, options, &block) #:nodoc:
-            uri = URI.parse(base_uri)
+            uri = URI.parse(base_uri || path)
             ActiveSupport::Notifications.instrument("request.http", hostname: uri.host) do
               super
             end


### PR DESCRIPTION
There are cases when base_uri is not set because url is fetched from VIP. In such situation error is raised:
```
URI::InvalidURIError:
       bad URI(is not URI?):
```
Fallback to path added as a fix. 