### PR TITLE
Remove inheritance from the Error class in airbrake_patches/httparty.rb

### DIFF
--- a/.github/workflows/secrets-scan-on-pr.yaml
+++ b/.github/workflows/secrets-scan-on-pr.yaml
@@ -1,0 +1,12 @@
+name: Secrets Scan
+
+on:
+  pull_request:
+
+jobs:
+  scan:
+    uses: AirHelp/gh-actions/.github/workflows/secrets-scan-on-pr.yaml@master
+    with:
+      application_name: ${{ github.event.repository.name }}
+      team_name: developers
+    secrets: inherit

--- a/lib/ah/lograge/airbrake_patches/httparty.rb
+++ b/lib/ah/lograge/airbrake_patches/httparty.rb
@@ -1,6 +1,6 @@
 # add short summary of HTTParty response
 module HTTParty
-  class ResponseError < Error
+  class ResponseError
     def to_airbrake
       params = {
         params: {

--- a/lib/ah/lograge/version.rb
+++ b/lib/ah/lograge/version.rb
@@ -1,5 +1,5 @@
 module Ah
   module Lograge
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
Bump up minor version od gem 🙈 
To be compatible with httparty 0.24 after https://github.com/AirHelp/ah-leadgun/security/dependabot/110, error raised in the apps > https://github.com/AirHelp/ah-leadgun/pull/928#issuecomment-3748332349